### PR TITLE
Make customer email required for tour bookings

### DIFF
--- a/tour-server/bookings/api/post_bookings.go
+++ b/tour-server/bookings/api/post_bookings.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log"
 	"net/http"
+	"strings"
 	"tour-server/bookings/dto"
 	"tour-server/bookings/models"
 	"tour-server/email"
@@ -32,10 +33,12 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": errMsg})
 		}
 
-		if req.CustomerEmail != "" {
-			if errMsg := middleware.ValidateEmail(req.CustomerEmail); errMsg != "" {
-				return c.JSON(http.StatusBadRequest, map[string]string{"error": errMsg})
-			}
+		if strings.TrimSpace(req.CustomerEmail) == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"error": "Email обов'язковий"})
+		}
+		if errMsg := middleware.ValidateEmail(req.CustomerEmail); errMsg != "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": errMsg})
 		}
 
 		if req.Seats == 0 || req.Seats > 20 {
@@ -120,18 +123,16 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 		}
 
 		// ── Email notification (async) ────────────────────────────────────
-		if req.CustomerEmail != "" {
-			tourTitle := getTourTitleByDateID(db, req.TourDateID)
-			email.NotifyBookingCreated(req.CustomerEmail, email.BookingNotification{
-				CustomerName: req.CustomerName,
-				TourTitle:    tourTitle,
-				Seats:        int(req.Seats),
-				TotalPrice:   calculatedPrice,
-				BookingID:    booking.ID,
-				Status:       "pending",
-			})
-			log.Printf("Booking created email queued: #%d → %s", booking.ID, req.CustomerEmail)
-		}
+		tourTitle := getTourTitleByDateID(db, req.TourDateID)
+		email.NotifyBookingCreated(req.CustomerEmail, email.BookingNotification{
+			CustomerName: req.CustomerName,
+			TourTitle:    tourTitle,
+			Seats:        int(req.Seats),
+			TotalPrice:   calculatedPrice,
+			BookingID:    booking.ID,
+			Status:       "pending",
+		})
+		log.Printf("Booking created email queued: #%d → %s", booking.ID, req.CustomerEmail)
 
 		return c.JSON(http.StatusOK, map[string]interface{}{
 			"message":     "Booking successful",

--- a/tour-server/bookings/api/post_bookings_test.go
+++ b/tour-server/bookings/api/post_bookings_test.go
@@ -93,6 +93,7 @@ func TestPostBookings_ZeroSeats(t *testing.T) {
 	body := dto.BookingRequest{
 		TourDateID:    1,
 		CustomerName:  "Артем",
+		CustomerEmail: "user@example.com",
 		CustomerPhone: "+380951234567",
 		Seats:         0,
 	}
@@ -117,6 +118,7 @@ func TestPostBookings_TooManySeats(t *testing.T) {
 	body := dto.BookingRequest{
 		TourDateID:    1,
 		CustomerName:  "Артем",
+		CustomerEmail: "user@example.com",
 		CustomerPhone: "+380951234567",
 		Seats:         21,
 	}
@@ -141,6 +143,7 @@ func TestPostBookings_ZeroTourDateID(t *testing.T) {
 	body := dto.BookingRequest{
 		TourDateID:    0,
 		CustomerName:  "Артем",
+		CustomerEmail: "user@example.com",
 		CustomerPhone: "+380951234567",
 		Seats:         2,
 	}
@@ -156,6 +159,37 @@ func TestPostBookings_ZeroTourDateID(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPostBookings_EmptyEmail(t *testing.T) {
+	e := setupEcho()
+
+	body := dto.BookingRequest{
+		TourDateID:    1,
+		CustomerName:  "Артем",
+		CustomerEmail: "",
+		CustomerPhone: "+380951234567",
+		Seats:         1,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/tour/bookings", strings.NewReader(string(jsonBody)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := PostBookings(nil)
+	handler(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["error"] == "" {
+		t.Error("expected error message for empty email")
 	}
 }
 

--- a/tour/src/pages/TourDetails/components/Form/Form.tsx
+++ b/tour/src/pages/TourDetails/components/Form/Form.tsx
@@ -74,7 +74,7 @@ export const Form = ({ tourTitle = "Тур" }: FormProps) => {
     return '';
   };
   const validateEmail = (v: string) => {
-    if (!v.trim()) return '';
+    if (!v.trim()) return "Email обов'язковий";
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? '' : 'Некоректний email';
   };
   const validatePhone = (v: string) => {
@@ -96,6 +96,7 @@ export const Form = ({ tourTitle = "Тур" }: FormProps) => {
   const isFormValid = () =>
     name.trim().length >= 2 &&
     validatePhone(phone) === '' &&
+    validateEmail(email) === '' &&
     !errors.name && !errors.email && !errors.phone &&
     seats >= 1 && seats <= available;
 
@@ -114,7 +115,7 @@ export const Form = ({ tourTitle = "Тур" }: FormProps) => {
     const emailErr = validateEmail(email);
     const phoneErr = validatePhone(phone);
     setErrors({ name: nameErr, email: emailErr, phone: phoneErr });
-    if (nameErr || phoneErr) return;
+    if (nameErr || emailErr || phoneErr) return;
     if (!tourDateId) { addToast({ title: 'Помилка', description: 'Не вдалося визначити дату туру', color: 'danger' }); return; }
 
     setStep('submitting');
@@ -324,7 +325,7 @@ export const Form = ({ tourTitle = "Тур" }: FormProps) => {
                     isDisabled={step === 'submitting'}
                     variant="bordered" startContent={<Phone size={16} className="text-default-400" />} />
 
-                  <Input label="Email (необов'язково)" placeholder="example@email.com"
+                  <Input isRequired label="Email" placeholder="example@email.com"
                     value={email}
                     onChange={e => { setEmail(e.target.value); setErrors(p => ({ ...p, email: validateEmail(e.target.value) })); }}
                     isInvalid={!!errors.email} errorMessage={errors.email}


### PR DESCRIPTION
Guests cannot receive booking confirmations or status updates without an email — phone is not used for notifications. Enforce email on both backend (post_bookings handler) and frontend (Form validation + required input), and add a test for the empty-email case.