### PR TITLE
Add guest "pay later" magic-link and cabinet pay button

### DIFF
--- a/tour-server/bookings/api/get_booking_by_token.go
+++ b/tour-server/bookings/api/get_booking_by_token.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+type bookingByTokenResponse struct {
+	ID            uint      `json:"id"`
+	TourTitle     string    `json:"tour_title"`
+	CustomerName  string    `json:"customer_name"`
+	Seats         uint      `json:"seats"`
+	TotalPrice    float64   `json:"total_price"`
+	Status        string    `json:"status"`
+	PaymentStatus string    `json:"payment_status"`
+	DateFrom      time.Time `json:"date_from"`
+	DateTo        time.Time `json:"date_to"`
+	FromLocation  string    `json:"from_location,omitempty"`
+	ToLocation    string    `json:"to_location,omitempty"`
+}
+
+// GetBookingByToken returns the minimal booking info needed for the
+// guest "pay later" magic-link page. Public endpoint — auth is the
+// token itself (random 64-char hex with a 7-day expiry).
+func GetBookingByToken(db *gorm.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		token := c.Param("token")
+		if len(token) != 64 {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Посилання недійсне"})
+		}
+
+		var row struct {
+			ID            uint       `gorm:"column:id"`
+			CustomerName  string     `gorm:"column:customer_name"`
+			Seats         uint       `gorm:"column:seats"`
+			TotalPrice    float64    `gorm:"column:total_price"`
+			Status        string     `gorm:"column:status"`
+			PaymentStatus string     `gorm:"column:payment_status"`
+			ExpiresAt     *time.Time `gorm:"column:payment_token_expires_at"`
+			TourTitle     string     `gorm:"column:tour_title"`
+			DateFrom      time.Time  `gorm:"column:date_from"`
+			DateTo        time.Time  `gorm:"column:date_to"`
+			FromLocation  string     `gorm:"column:from_location"`
+			ToLocation    string     `gorm:"column:to_location"`
+		}
+
+		err := db.Raw(`
+			SELECT b.id, b.customer_name, b.seats, b.total_price,
+				b.status, COALESCE(b.payment_status, 'pending') AS payment_status,
+				b.payment_token_expires_at,
+				t.title AS tour_title,
+				td.date_from, td.date_to,
+				COALESCE(fl.name, '') AS from_location,
+				COALESCE(tl.name, '') AS to_location
+			FROM bookings b
+			JOIN tour_dates td ON b.tour_date_id = td.id
+			JOIN tours t ON td.tour_id = t.id
+			LEFT JOIN locations fl ON td.from_location_id = fl.id
+			LEFT JOIN locations tl ON td.to_location_id = tl.id
+			WHERE b.payment_token = ?
+		`, token).Scan(&row).Error
+
+		if err != nil || row.ID == 0 {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Посилання недійсне"})
+		}
+
+		if row.ExpiresAt != nil && time.Now().After(*row.ExpiresAt) {
+			return c.JSON(http.StatusGone, map[string]string{"error": "Термін дії посилання сплив"})
+		}
+
+		return c.JSON(http.StatusOK, bookingByTokenResponse{
+			ID:            row.ID,
+			TourTitle:     row.TourTitle,
+			CustomerName:  row.CustomerName,
+			Seats:         row.Seats,
+			TotalPrice:    row.TotalPrice,
+			Status:        row.Status,
+			PaymentStatus: row.PaymentStatus,
+			DateFrom:      row.DateFrom,
+			DateTo:        row.DateTo,
+			FromLocation:  row.FromLocation,
+			ToLocation:    row.ToLocation,
+		})
+	}
+}

--- a/tour-server/bookings/api/get_user_bookings.go
+++ b/tour-server/bookings/api/get_user_bookings.go
@@ -25,6 +25,22 @@ func GetUserBookings(db *gorm.DB) echo.HandlerFunc {
 			})
 		}
 
+		paymentStatuses := make(map[uint]string, len(bookings))
+		if len(bookings) > 0 {
+			ids := make([]uint, 0, len(bookings))
+			for _, b := range bookings {
+				ids = append(ids, b.ID)
+			}
+			var rows []struct {
+				ID            uint   `gorm:"column:id"`
+				PaymentStatus string `gorm:"column:payment_status"`
+			}
+			db.Raw("SELECT id, COALESCE(payment_status, 'pending') AS payment_status FROM bookings WHERE id IN ?", ids).Scan(&rows)
+			for _, r := range rows {
+				paymentStatuses[r.ID] = r.PaymentStatus
+			}
+		}
+
 		var response []dto.BookingResponse
 		for _, booking := range bookings {
 			bookingDTO := dto.BookingResponse{
@@ -37,9 +53,13 @@ func GetUserBookings(db *gorm.DB) echo.HandlerFunc {
 				Seats:         int(booking.Seats),
 				TotalPrice:    booking.TotalPrice,
 				Status:        booking.Status,
+				PaymentStatus: paymentStatuses[booking.ID],
 				BookedAt:      booking.BookedAt,
 				DateFrom:      booking.TourDate.DateFrom,
 				DateTo:        booking.TourDate.DateTo,
+			}
+			if bookingDTO.PaymentStatus == "" {
+				bookingDTO.PaymentStatus = "pending"
 			}
 
 			if booking.TourDate.FromLocation.ID != 0 {

--- a/tour-server/bookings/api/post_bookings.go
+++ b/tour-server/bookings/api/post_bookings.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
+	"time"
 	"tour-server/bookings/dto"
 	"tour-server/bookings/models"
 	"tour-server/email"
@@ -122,6 +127,25 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 				"error": "Failed to create booking"})
 		}
 
+		// ── Magic-link payment token for guests ───────────────────────────
+		var paymentURL string
+		if isGuestBooking {
+			token, err := generatePaymentToken()
+			if err != nil {
+				log.Printf("Failed to generate payment token: %v", err)
+			} else {
+				expiresAt := time.Now().Add(7 * 24 * time.Hour)
+				if err := db.Exec(
+					"UPDATE bookings SET payment_token = ?, payment_token_expires_at = ? WHERE id = ?",
+					token, expiresAt, booking.ID,
+				).Error; err != nil {
+					log.Printf("Failed to save payment token: %v", err)
+				} else {
+					paymentURL = buildPaymentURL(token)
+				}
+			}
+		}
+
 		// ── Email notification (async) ────────────────────────────────────
 		tourTitle := getTourTitleByDateID(db, req.TourDateID)
 		email.NotifyBookingCreated(req.CustomerEmail, email.BookingNotification{
@@ -131,6 +155,7 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 			TotalPrice:   calculatedPrice,
 			BookingID:    booking.ID,
 			Status:       "pending",
+			PaymentURL:   paymentURL,
 		})
 		log.Printf("Booking created email queued: #%d → %s", booking.ID, req.CustomerEmail)
 
@@ -141,6 +166,22 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 			"total_price": calculatedPrice,
 		})
 	}
+}
+
+func generatePaymentToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func buildPaymentURL(token string) string {
+	base := os.Getenv("FRONTEND_URL")
+	if base == "" {
+		base = "https://openworld.local"
+	}
+	return fmt.Sprintf("%s/pay/%s", base, token)
 }
 
 func getTourTitleByDateID(db *gorm.DB, tourDateID uint) string {

--- a/tour-server/bookings/dto/booking_response.go
+++ b/tour-server/bookings/dto/booking_response.go
@@ -16,5 +16,6 @@ type BookingResponse struct {
 	Seats         int       `json:"seats"`
 	TotalPrice    float64   `json:"total_price"`
 	Status        string    `json:"status"`
+	PaymentStatus string    `json:"payment_status"`
 	BookedAt      time.Time `json:"booked_at"`
 }

--- a/tour-server/bookings/migration_payment_token.sql
+++ b/tour-server/bookings/migration_payment_token.sql
@@ -1,0 +1,11 @@
+-- Migration: add payment_token to bookings for guest "pay later" magic-links.
+-- Token is sent in the booking-created email and lets unauthenticated guests
+-- return to the payment flow without having to log in or remember a booking ID.
+
+ALTER TABLE bookings
+    ADD COLUMN IF NOT EXISTS payment_token VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS payment_token_expires_at TIMESTAMP;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_bookings_payment_token
+    ON bookings(payment_token)
+    WHERE payment_token IS NOT NULL;

--- a/tour-server/email/templates.go
+++ b/tour-server/email/templates.go
@@ -10,6 +10,7 @@ type BookingNotification struct {
 	TotalPrice   float64
 	BookingID    uint
 	Status       string // "confirmed", "cancelled", "pending", "paid"
+	PaymentURL   string // optional magic-link to resume payment (guest bookings)
 }
 
 // NotifyBookingConfirmed sends email when booking is confirmed by admin.
@@ -63,6 +64,7 @@ type tmplData struct {
 	TotalPrice   string
 	BookingID    uint
 	SeatsWord    string
+	PaymentURL   string
 }
 
 func templateData(n BookingNotification) tmplData {
@@ -79,6 +81,7 @@ func templateData(n BookingNotification) tmplData {
 		TotalPrice:   formatPrice(n.TotalPrice),
 		BookingID:    n.BookingID,
 		SeatsWord:    word,
+		PaymentURL:   n.PaymentURL,
 	}
 }
 
@@ -353,13 +356,26 @@ const createdTemplate = `<!DOCTYPE html>
 
   <table width="100%" cellpadding="0" cellspacing="0" style="background:#fffbeb;border:1px solid #fde68a;border-radius:10px;margin-bottom:16px;">
   <tr><td style="padding:14px 18px;">
-    <p style="color:#92400e;font-size:14px;font-weight:600;margin:0;">⏳ Статус: Очікує підтвердження</p>
+    <p style="color:#92400e;font-size:14px;font-weight:600;margin:0;">⏳ Статус: Очікує оплату</p>
   </td></tr>
   </table>
 
+  {{if .PaymentURL}}
+  <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:16px;">
+  <tr><td align="center" style="padding:8px 0 4px;">
+    <a href="{{.PaymentURL}}" style="display:inline-block;background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff;text-decoration:none;font-weight:700;font-size:15px;padding:14px 32px;border-radius:10px;box-shadow:0 4px 12px rgba(99,102,241,0.3);">
+      💳 Перейти до оплати
+    </a>
+  </td></tr>
+  <tr><td align="center" style="padding-top:10px;">
+    <p style="color:#94a3b8;font-size:12px;margin:0;">Посилання діє 7 днів. Після оплати бронювання буде підтверджено автоматично.</p>
+  </td></tr>
+  </table>
+  {{else}}
   <p style="color:#64748b;font-size:14px;line-height:1.6;margin:0;">
-    Ви можете переглянути статус бронювання в особистому кабінеті на сайті.
+    Ви можете переглянути статус бронювання та оплатити його в особистому кабінеті на сайті.
   </p>
+  {{end}}
 </td></tr>
 
 <tr><td style="background:#f8fafc;border-top:1px solid #e2e8f0;padding:24px 40px;text-align:center;">

--- a/tour-server/liqpay/api/create_payment_by_token.go
+++ b/tour-server/liqpay/api/create_payment_by_token.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+	"tour-server/liqpay"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+type CreatePaymentByTokenRequest struct {
+	Token string `json:"token"`
+}
+
+// CreatePaymentByToken is the guest-facing counterpart of CreatePayment.
+// It authenticates the caller via a one-time-ish payment token (sent in the
+// booking-created email) instead of a JWT, so unauthenticated guests can
+// resume payment without logging in.
+func CreatePaymentByToken(db *gorm.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req CreatePaymentByTokenRequest
+		if err := c.Bind(&req); err != nil || len(req.Token) != 64 {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Невірний токен"})
+		}
+
+		var booking struct {
+			ID            uint       `gorm:"column:id"`
+			TotalPrice    float64    `gorm:"column:total_price"`
+			CustomerName  string     `gorm:"column:customer_name"`
+			PaymentStatus string     `gorm:"column:payment_status"`
+			Status        string     `gorm:"column:status"`
+			ExpiresAt     *time.Time `gorm:"column:payment_token_expires_at"`
+			TourTitle     string     `gorm:"column:tour_title"`
+		}
+
+		err := db.Raw(`
+			SELECT b.id, b.total_price, b.customer_name,
+				COALESCE(b.payment_status, 'pending') AS payment_status,
+				b.status, b.payment_token_expires_at,
+				t.title AS tour_title
+			FROM bookings b
+			JOIN tour_dates td ON b.tour_date_id = td.id
+			JOIN tours t ON td.tour_id = t.id
+			WHERE b.payment_token = ?
+		`, req.Token).Scan(&booking).Error
+
+		if err != nil || booking.ID == 0 {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Посилання недійсне"})
+		}
+
+		if booking.ExpiresAt != nil && time.Now().After(*booking.ExpiresAt) {
+			return c.JSON(http.StatusGone, map[string]string{"error": "Термін дії посилання сплив"})
+		}
+
+		if booking.PaymentStatus == "paid" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Вже оплачено"})
+		}
+
+		if booking.Status == "cancelled" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Бронювання скасовано"})
+		}
+
+		orderID := fmt.Sprintf("booking-%d-%d", booking.ID, time.Now().Unix())
+		db.Exec("UPDATE bookings SET liqpay_order_id = ? WHERE id = ?", orderID, booking.ID)
+
+		publicKey := os.Getenv("LIQPAY_PUBLIC_KEY")
+		privateKey := os.Getenv("LIQPAY_PRIVATE_KEY")
+		callbackURL := os.Getenv("LIQPAY_CALLBACK_URL")
+
+		params := liqpay.Params{
+			"public_key":  publicKey,
+			"version":     "3",
+			"action":      "pay",
+			"amount":      fmt.Sprintf("%.2f", booking.TotalPrice),
+			"currency":    "UAH",
+			"description": fmt.Sprintf("Тур: %s — %s", booking.TourTitle, booking.CustomerName),
+			"order_id":    orderID,
+			"server_url":  callbackURL,
+			"sandbox":     "1",
+		}
+
+		data, err := liqpay.Encode(params)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to encode payment"})
+		}
+
+		signature := liqpay.Sign(data, privateKey)
+
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"data":       data,
+			"signature":  signature,
+			"order_id":   orderID,
+			"booking_id": booking.ID,
+			"amount":     booking.TotalPrice,
+		})
+	}
+}

--- a/tour-server/server.go
+++ b/tour-server/server.go
@@ -188,6 +188,10 @@ func main() {
 	e.GET("/tour-reviews/:id", tourreviews.GetReviewsByTourID(database.DB))
 	e.GET("/stats", api.GetPublicStats(database.DB))
 
+	// Guest "pay later" magic-link endpoints (token-authenticated, no JWT)
+	e.GET("/bookings/by-token/:token", bookings.GetBookingByToken(database.DB))
+	e.POST("/liqpay/create-payment-by-token", liqpayAPI.CreatePaymentByToken(database.DB), paymentRL)
+
 	// ========================================
 	// OPTIONAL AUTH (guests + authorized users)
 	// ========================================

--- a/tour/src/components/App/App.tsx
+++ b/tour/src/components/App/App.tsx
@@ -13,6 +13,7 @@ import { Tours } from '../../pages/Tours/Tours';
 import { TourDetails } from '../../pages/TourDetails/TourDetails';
 import { UserProfile } from '../../pages/Profile/UserProfile';
 import { UserBookings } from '../../pages/Bookings/UserBookings';
+import { GuestPay } from '../../pages/GuestPay/GuestPay';
 import { UserFavorites } from '../../pages/Favorites/UserFavorites';
 import { AdminLayout, Dashboard, AdminBookings, AdminTours, AdminUsers } from '../../pages/Admin';
 import { ForgotPasswordPage, ResetPasswordPage } from '../../pages/ResetPassword/ResetPassword';
@@ -72,6 +73,7 @@ function App() {
                   <Route path="/TourDetails/:id" element={<TourDetails />} />
                   <Route path="/profile" element={<UserProfile />} />
                   <Route path="/bookings" element={<UserBookings />} />
+                  <Route path="/pay/:token" element={<GuestPay />} />
                   <Route path="/favorites" element={<UserFavorites />} />
                   <Route path="/settings" element={<UserSettings />} />
 

--- a/tour/src/pages/Bookings/UserBookings.tsx
+++ b/tour/src/pages/Bookings/UserBookings.tsx
@@ -11,6 +11,7 @@ import {
   CalendarDays, MapPin, Users, CreditCard, Clock, Phone, Mail,
   Eye, AlertCircle, CheckCircle, XCircle, User, Star,
 } from 'lucide-react';
+import { openLiqPayWidget } from '../../hooks/useLiqPay';
 
 const API = process.env.REACT_APP_API_URL!;
 
@@ -28,6 +29,7 @@ interface Booking {
   seats: number;
   total_price: number;
   status: 'pending' | 'confirmed' | 'cancelled';
+  payment_status?: 'pending' | 'paid' | 'failed' | 'reversed';
   booked_at: string;
 }
 
@@ -66,6 +68,8 @@ export const UserBookings: React.FC = () => {
   const [selectedBooking, setSelectedBooking] = useState<Booking | null>(null);
   const [isCancelling, setIsCancelling] = useState(false);
   const [cancelError, setCancelError] = useState('');
+  const [isPaying, setIsPaying] = useState(false);
+  const [payError, setPayError] = useState('');
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   // Rating modal state
@@ -94,6 +98,36 @@ export const UserBookings: React.FC = () => {
       setError(err instanceof Error ? err.message : 'Помилка завантаження бронювань');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handlePayBooking = async (booking: Booking) => {
+    setIsPaying(true);
+    setPayError('');
+    try {
+      const res = await fetch(`${API}/liqpay/create-payment`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ booking_id: booking.id }),
+      });
+      if (!res.ok) { const d = await res.json(); throw new Error(d.error || 'Не вдалося ініціювати оплату'); }
+      const { data, signature } = await res.json();
+
+      await openLiqPayWidget({
+        data,
+        signature,
+        amount: booking.total_price,
+        tourTitle: booking.tour_title,
+        seats: booking.seats,
+        onSuccess: async () => {
+          await fetchBookings();
+          onClose();
+        },
+      });
+    } catch (err) {
+      setPayError(err instanceof Error ? err.message : 'Помилка оплати');
+    } finally {
+      setIsPaying(false);
     }
   };
 
@@ -278,7 +312,7 @@ export const UserBookings: React.FC = () => {
                               Оцінити
                             </Button>
                           )}
-                          <Button isIconOnly variant="light" onClick={() => { setSelectedBooking(booking); setCancelError(''); onOpen(); }}>
+                          <Button isIconOnly variant="light" onClick={() => { setSelectedBooking(booking); setCancelError(''); setPayError(''); onOpen(); }}>
                             <Eye size={18} />
                           </Button>
                         </div>
@@ -308,7 +342,7 @@ export const UserBookings: React.FC = () => {
 
       {/* ── Details modal ── */}
       {selectedBooking && (
-        <Modal isOpen={isOpen} onClose={() => { onClose(); setCancelError(''); }} size="3xl" className="booking-modal" scrollBehavior="inside">
+        <Modal isOpen={isOpen} onClose={() => { onClose(); setCancelError(''); setPayError(''); }} size="3xl" className="booking-modal" scrollBehavior="inside">
           <ModalContent>
             <ModalHeader className="booking-modal__header">
               <div className="booking-modal__header-content">
@@ -375,16 +409,30 @@ export const UserBookings: React.FC = () => {
                         <div className="booking-modal__actions-info">
                           <AlertCircle size={20} className="booking-modal__actions-icon" />
                           <div>
-                            <h4>Очікує підтвердження</h4>
-                            <p>Ви можете скасувати бронювання до підтвердження.</p>
+                            <h4>{selectedBooking.payment_status === 'paid' ? 'Очікує підтвердження' : 'Очікує оплату'}</h4>
+                            <p>
+                              {selectedBooking.payment_status === 'paid'
+                                ? 'Оплату отримано, менеджер скоро підтвердить бронювання.'
+                                : 'Оплатіть зараз, щоб підтвердити бронювання. Інакше — можете скасувати.'}
+                            </p>
                             {cancelError && <p style={{ color: '#ef4444', marginTop: '0.5rem', fontSize: '0.875rem' }}>{cancelError}</p>}
+                            {payError && <p style={{ color: '#ef4444', marginTop: '0.5rem', fontSize: '0.875rem' }}>{payError}</p>}
                           </div>
                         </div>
-                        <Button color="danger" variant="light" startContent={<XCircle size={16} />}
-                          isLoading={isCancelling} isDisabled={isCancelling}
-                          onClick={() => handleCancelBooking(selectedBooking.id)}>
-                          Скасувати бронювання
-                        </Button>
+                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                          {selectedBooking.payment_status !== 'paid' && (
+                            <Button color="primary" variant="solid" startContent={<CreditCard size={16} />}
+                              isLoading={isPaying} isDisabled={isPaying || isCancelling}
+                              onClick={() => handlePayBooking(selectedBooking)}>
+                              Оплатити
+                            </Button>
+                          )}
+                          <Button color="danger" variant="light" startContent={<XCircle size={16} />}
+                            isLoading={isCancelling} isDisabled={isCancelling || isPaying}
+                            onClick={() => handleCancelBooking(selectedBooking.id)}>
+                            Скасувати бронювання
+                          </Button>
+                        </div>
                       </div>
                     </CardBody>
                   </Card>
@@ -420,7 +468,7 @@ export const UserBookings: React.FC = () => {
               </div>
             </ModalBody>
             <ModalFooter className="booking-modal__footer">
-              <Button color="default" variant="light" onPress={() => { onClose(); setCancelError(''); }}>Закрити</Button>
+              <Button color="default" variant="light" onPress={() => { onClose(); setCancelError(''); setPayError(''); }}>Закрити</Button>
             </ModalFooter>
           </ModalContent>
         </Modal>

--- a/tour/src/pages/GuestPay/GuestPay.tsx
+++ b/tour/src/pages/GuestPay/GuestPay.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Card, CardBody, CardHeader, Button, Chip, Divider, Spinner,
+} from '@heroui/react';
+import {
+  CalendarDays, MapPin, Users, CreditCard, CheckCircle,
+  XCircle, AlertCircle, ShieldCheck,
+} from 'lucide-react';
+import { Navbar } from '../../components/Navbar/Navbar';
+import { Footer } from '../Main/components/Footer/Footer';
+import { openLiqPayWidget } from '../../hooks/useLiqPay';
+
+const API = process.env.REACT_APP_API_URL!;
+
+interface BookingByToken {
+  id: number;
+  tour_title: string;
+  customer_name: string;
+  seats: number;
+  total_price: number;
+  status: 'pending' | 'confirmed' | 'cancelled';
+  payment_status: 'pending' | 'paid' | 'failed' | 'reversed';
+  date_from: string;
+  date_to: string;
+  from_location?: string;
+  to_location?: string;
+}
+
+const formatDate = (s: string) =>
+  new Date(s).toLocaleDateString('uk-UA', { year: 'numeric', month: 'long', day: 'numeric' });
+const formatPrice = (p: number) =>
+  new Intl.NumberFormat('uk-UA', { style: 'currency', currency: 'UAH' }).format(p);
+
+export const GuestPay: React.FC = () => {
+  const { token = '' } = useParams<{ token: string }>();
+  const [booking, setBooking] = useState<BookingByToken | null>(null);
+  const [loadError, setLoadError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [paying, setPaying] = useState(false);
+  const [payError, setPayError] = useState('');
+  const [paid, setPaid] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(`${API}/bookings/by-token/${encodeURIComponent(token)}`);
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Не вдалося завантажити бронювання');
+        if (!cancelled) setBooking(data);
+      } catch (err) {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : 'Помилка завантаження');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [token]);
+
+  const handlePay = async () => {
+    if (!booking) return;
+    setPaying(true);
+    setPayError('');
+    try {
+      const res = await fetch(`${API}/liqpay/create-payment-by-token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Не вдалося ініціювати оплату');
+
+      await openLiqPayWidget({
+        data: data.data,
+        signature: data.signature,
+        amount: booking.total_price,
+        tourTitle: booking.tour_title,
+        seats: booking.seats,
+        onSuccess: () => {
+          setPaid(true);
+          setBooking(prev => prev ? { ...prev, payment_status: 'paid', status: 'confirmed' } : prev);
+        },
+      });
+    } catch (err) {
+      setPayError(err instanceof Error ? err.message : 'Помилка оплати');
+    } finally {
+      setPaying(false);
+    }
+  };
+
+  const renderBody = () => {
+    if (loading) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12, padding: '48px 0' }}>
+          <Spinner size="lg" />
+          <p style={{ color: '#64748b' }}>Завантаження бронювання...</p>
+        </div>
+      );
+    }
+
+    if (loadError || !booking) {
+      return (
+        <Card>
+          <CardBody style={{ textAlign: 'center', padding: '32px 24px' }}>
+            <AlertCircle size={48} style={{ color: '#ef4444', margin: '0 auto 12px' }} />
+            <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 6 }}>Посилання недоступне</h3>
+            <p style={{ color: '#64748b', marginBottom: 16 }}>{loadError || 'Бронювання не знайдено'}</p>
+            <Button color="primary" onClick={() => window.location.href = '/'}>На головну</Button>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    const isPaid = paid || booking.payment_status === 'paid';
+    const isCancelled = booking.status === 'cancelled';
+
+    return (
+      <Card>
+        <CardHeader style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 8, padding: '20px 24px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center', gap: 12 }}>
+            <h2 style={{ fontSize: 20, fontWeight: 800, margin: 0 }}>{booking.tour_title}</h2>
+            <Chip
+              color={isPaid ? 'success' : isCancelled ? 'danger' : 'warning'}
+              variant="flat"
+              startContent={isPaid ? <CheckCircle size={14} /> : isCancelled ? <XCircle size={14} /> : <AlertCircle size={14} />}
+            >
+              {isPaid ? 'Оплачено' : isCancelled ? 'Скасовано' : 'Очікує оплату'}
+            </Chip>
+          </div>
+          <p style={{ color: '#64748b', fontSize: 14, margin: 0 }}>Бронювання #{booking.id} — {booking.customer_name}</p>
+        </CardHeader>
+        <Divider />
+        <CardBody style={{ padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#334155' }}>
+            <CalendarDays size={18} style={{ color: '#6366f1' }} />
+            <span>{formatDate(booking.date_from)} – {formatDate(booking.date_to)}</span>
+          </div>
+          {(booking.from_location || booking.to_location) && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#334155' }}>
+              <MapPin size={18} style={{ color: '#6366f1' }} />
+              <span>{booking.from_location} → {booking.to_location}</span>
+            </div>
+          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#334155' }}>
+            <Users size={18} style={{ color: '#6366f1' }} />
+            <span>{booking.seats} {booking.seats === 1 ? 'місце' : booking.seats <= 4 ? 'місця' : 'місць'}</span>
+          </div>
+          <Divider />
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ color: '#64748b', fontWeight: 600 }}>До оплати</span>
+            <span style={{ fontSize: 22, fontWeight: 900, color: '#0f172a' }}>{formatPrice(booking.total_price)}</span>
+          </div>
+
+          {isPaid ? (
+            <div style={{ background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: 12, padding: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+              <CheckCircle size={24} style={{ color: '#10b981', flexShrink: 0 }} />
+              <div>
+                <p style={{ fontWeight: 700, color: '#065f46', margin: '0 0 2px' }}>Оплату отримано</p>
+                <p style={{ color: '#047857', fontSize: 14, margin: 0 }}>Підтвердження надіслано на ваш email.</p>
+              </div>
+            </div>
+          ) : isCancelled ? (
+            <div style={{ background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 12, padding: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+              <XCircle size={24} style={{ color: '#ef4444', flexShrink: 0 }} />
+              <div>
+                <p style={{ fontWeight: 700, color: '#991b1b', margin: '0 0 2px' }}>Бронювання скасовано</p>
+                <p style={{ color: '#b91c1c', fontSize: 14, margin: 0 }}>Оплата більше неможлива.</p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {payError && (
+                <div style={{ background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 12, padding: 12, color: '#b91c1c', fontSize: 14 }}>
+                  {payError}
+                </div>
+              )}
+              <Button
+                color="primary"
+                size="lg"
+                startContent={<CreditCard size={18} />}
+                isLoading={paying}
+                isDisabled={paying}
+                onClick={handlePay}
+              >
+                Оплатити {formatPrice(booking.total_price)}
+              </Button>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#94a3b8', fontSize: 12, justifyContent: 'center' }}>
+                <ShieldCheck size={14} /> Оплата через LiqPay — захищено SSL
+              </div>
+            </>
+          )}
+        </CardBody>
+      </Card>
+    );
+  };
+
+  return (
+    <>
+      <Navbar />
+      <div style={{ maxWidth: 600, margin: '0 auto', padding: '32px 16px 64px' }}>
+        <h1 style={{ fontSize: 24, fontWeight: 800, marginBottom: 16, color: '#0f172a' }}>Оплата бронювання</h1>
+        {renderBody()}
+      </div>
+      <Footer />
+    </>
+  );
+};


### PR DESCRIPTION
Previously, if a user closed the LiqPay widget without paying, their booking sat in a pending/unpaid limbo with no way to resume payment — authorized users had no Pay button in their cabinet, and guests had no way back in at all.

Backend:
- New columns payment_token + payment_token_expires_at on bookings (see migration_payment_token.sql; run before deploying).
- PostBookings generates a 32-byte token for guest bookings and embeds a 7-day magic-link in the created-booking email.
- New public endpoints:
  - GET  /bookings/by-token/:token        minimal booking info
  - POST /liqpay/create-payment-by-token  payment intent for guests
- GetUserBookings now returns payment_status so the UI can distinguish
  "awaiting payment" from "awaiting admin confirmation".

Frontend:
- New /pay/:token page renders booking summary and a Pay button that reuses the existing LiqPay widget.
- UserBookings cabinet shows a Pay button on pending+unpaid bookings alongside Cancel, and updates the pending-status copy to reflect whether payment or admin confirmation is what's missing.