### PR TITLE
Refactor LiqPay payment confirmation to use status API

### DIFF
--- a/tour-server/liqpay/api/confirm_payment.go
+++ b/tour-server/liqpay/api/confirm_payment.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 	"tour-server/liqpay"
 
@@ -12,62 +16,70 @@ import (
 )
 
 // POST /liqpay/confirm
-// Фронтенд викликає після успішної оплати з data+signature від LiqPay віджету
-// Верифікуємо підпис і підтверджуємо бронювання
+// Фронтенд викликає після успіху у віджеті, передаючи лише order_id.
+// Сервер сам звертається до LiqPay status API, щоб перевірити стан платежу,
+// бо подія liqpay.callback у віджеті не повертає підписаних data+signature.
 func ConfirmPayment(db *gorm.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req struct {
-			Data      string `json:"data"`
-			Signature string `json:"signature"`
+			OrderID string `json:"order_id"`
 		}
-		if err := c.Bind(&req); err != nil || req.Data == "" || req.Signature == "" {
+		if err := c.Bind(&req); err != nil || req.OrderID == "" {
 			return c.JSON(http.StatusBadRequest, map[string]string{
-				"error": "data and signature required",
+				"error": "order_id required",
 			})
 		}
 
+		publicKey := os.Getenv("LIQPAY_PUBLIC_KEY")
 		privateKey := os.Getenv("LIQPAY_PRIVATE_KEY")
 
-		// Верифікуємо підпис — якщо підпис неправильний, відхиляємо
-		if !liqpay.Verify(req.Data, req.Signature, privateKey) {
-			return c.JSON(http.StatusForbidden, map[string]string{
-				"error": "invalid signature",
-			})
+		statusParams := liqpay.Params{
+			"public_key": publicKey,
+			"version":    "3",
+			"action":     "status",
+			"order_id":   req.OrderID,
 		}
-
-		// Декодуємо payload
-		payload, err := liqpay.Decode(req.Data)
+		data, err := liqpay.Encode(statusParams)
 		if err != nil {
-			return c.JSON(http.StatusBadRequest, map[string]string{
-				"error": "decode error",
-			})
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "encode failed"})
+		}
+		signature := liqpay.Sign(data, privateKey)
+
+		form := url.Values{}
+		form.Set("data", data)
+		form.Set("signature", signature)
+
+		httpClient := &http.Client{Timeout: 10 * time.Second}
+		resp, err := httpClient.Post(
+			"https://www.liqpay.ua/api/request",
+			"application/x-www-form-urlencoded",
+			strings.NewReader(form.Encode()),
+		)
+		if err != nil {
+			return c.JSON(http.StatusBadGateway, map[string]string{"error": "liqpay unreachable"})
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return c.JSON(http.StatusBadGateway, map[string]string{"error": "bad liqpay response"})
 		}
 
-		orderID, _ := payload["order_id"].(string)
 		status, _ := payload["status"].(string)
 		paymentID := ""
 		if pid, ok := payload["payment_id"].(float64); ok {
 			paymentID = fmt.Sprintf("%.0f", pid)
 		}
 
-		if orderID == "" {
-			return c.JSON(http.StatusBadRequest, map[string]string{
-				"error": "missing order_id",
-			})
-		}
-
-		// Тільки success і sandbox вважаються успішною оплатою
 		if status != "success" && status != "sandbox" {
 			return c.JSON(http.StatusBadRequest, map[string]string{
 				"error": fmt.Sprintf("payment status is '%s', not successful", status),
 			})
 		}
 
-		// Підтверджуємо бронювання
-		if err := confirmBookingByOrder(db, orderID, paymentID); err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{
-				"error": err.Error(),
-			})
+		if err := confirmBookingByOrder(db, req.OrderID, paymentID); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
 
 		return c.JSON(http.StatusOK, map[string]interface{}{
@@ -95,7 +107,6 @@ func confirmBookingByOrder(db *gorm.DB, orderID, paymentID string) error {
 		return fmt.Errorf("booking not found for order %s", orderID)
 	}
 
-	// Ідемпотентність
 	if booking.PaymentStatus == "paid" {
 		tx.Rollback()
 		return nil

--- a/tour-server/migration_cleanup_duplicates.sql
+++ b/tour-server/migration_cleanup_duplicates.sql
@@ -1,0 +1,34 @@
+-- Видалення дублюючих тригерів та індексів.
+--
+-- Контекст:
+--   * На tour_reviews існували два набори тригерів, що виконують одну й ту саму
+--     роботу (перерахунок tours.rating): trg_tour_rating_insert/update/delete
+--     та trg_update_tour_rating. Залишаємо один універсальний trg_update_tour_rating.
+--   * Деякі індекси були створені двічі під різними іменами.
+--   * Тригер trg_update_tour_rating_from_ratings на tour_ratings залишений: він
+--     обслуговує окрему таблицю tour_ratings, яка використовується ендпоінтом
+--     POST /tour-ratings (див. tour-server/tourratings/api/post_tour_rating.go).
+
+BEGIN;
+
+-- 1. Дублюючі тригери на tour_reviews ---------------------------------------
+DROP TRIGGER IF EXISTS trg_tour_rating_insert ON tour_reviews;
+DROP TRIGGER IF EXISTS trg_tour_rating_update ON tour_reviews;
+DROP TRIGGER IF EXISTS trg_tour_rating_delete ON tour_reviews;
+
+-- 2. Дублюючі індекси -------------------------------------------------------
+-- tour_ratings: лишаємо канонічні *_tour_id / *_user_id.
+DROP INDEX IF EXISTS idx_tour_ratings_tour;
+DROP INDEX IF EXISTS idx_tour_ratings_user;
+
+-- tour_reviews
+DROP INDEX IF EXISTS idx_tour_reviews_parent;
+
+-- tour_review_likes
+DROP INDEX IF EXISTS idx_tour_review_likes_review;
+
+-- bookings: idx_bookings_liqpay_order (UNIQUE partial) лишаємо, бо він
+-- одночасно й індекс, і обмеження унікальності; не-унікальний дублікат прибираємо.
+DROP INDEX IF EXISTS idx_bookings_liqpay_order_id;
+
+COMMIT;

--- a/tour/src/hooks/useLiqPay.ts
+++ b/tour/src/hooks/useLiqPay.ts
@@ -33,13 +33,13 @@ declare global {
 
 const API = process.env.REACT_APP_API_URL!;
 
-async function confirmPaymentOnServer(data: string, signature: string): Promise<void> {
+async function confirmPaymentOnServer(orderID: string): Promise<void> {
   const token = localStorage.getItem('tour_auth_token');
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const res = await fetch(`${API}/liqpay/confirm`, {
     method: 'POST', headers,
-    body: JSON.stringify({ data, signature }),
+    body: JSON.stringify({ order_id: orderID }),
   });
   if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Confirmation failed'); }
 }
@@ -198,15 +198,23 @@ export async function openLiqPayWidget(opts: LiqPayWidgetOptions): Promise<void>
 
   widget
     .on('liqpay.callback', async (callbackData: any) => {
-      if (callbackData.status === 'success' || callbackData.status === 'sandbox') {
-        try {
-          await confirmPaymentOnServer(callbackData.data, callbackData.signature);
-        } catch (err) {
-          console.error('Payment confirmation error:', err);
-        }
-        if (document.body.contains(overlay)) document.body.removeChild(overlay);
-        opts.onSuccess?.();
+      if (callbackData.status !== 'success' && callbackData.status !== 'sandbox') {
+        return; // LiqPay сам покаже причину у віджеті
       }
+      const orderID = callbackData.order_id;
+      if (!orderID) {
+        console.error('LiqPay callback без order_id', callbackData);
+        return;
+      }
+      try {
+        await confirmPaymentOnServer(orderID);
+      } catch (err) {
+        console.error('Payment confirmation error:', err);
+        alert('Оплата пройшла, але сервер не зміг її підтвердити. Оновіть сторінку через хвилину.');
+        return; // НЕ закриваємо віджет і НЕ кличемо onSuccess
+      }
+      if (document.body.contains(overlay)) document.body.removeChild(overlay);
+      opts.onSuccess?.();
     })
     .on('liqpay.close', () => {
       if (document.body.contains(overlay)) document.body.removeChild(overlay);


### PR DESCRIPTION
## Summary
Changed the payment confirmation flow to have the server query LiqPay's status API instead of relying on signed data+signature from the frontend widget. This improves security and reliability by eliminating the need to pass sensitive payment data through the client.

## Key Changes

**Backend (Go)**
- Modified `/liqpay/confirm` endpoint to accept only `order_id` instead of `data` and `signature`
- Server now makes a direct request to LiqPay's status API (`https://www.liqpay.ua/api/request`) to verify payment status
- Removed client-side signature verification since the server now verifies directly with LiqPay
- Added proper error handling for LiqPay API communication failures
- Cleaned up comments to reflect the new flow

**Frontend (React/TypeScript)**
- Updated `confirmPaymentOnServer()` to send only `order_id` instead of `data` and `signature`
- Modified `liqpay.callback` handler to extract `order_id` from callback data
- Improved error handling: if confirmation fails, shows user alert and prevents closing the widget
- Added validation to ensure `order_id` is present in callback data

**Database**
- Added migration script to clean up duplicate triggers and indexes:
  - Removed duplicate rating calculation triggers on `tour_reviews` table
  - Removed duplicate indexes across multiple tables
  - Kept canonical indexes and the `trg_update_tour_rating` trigger

## Implementation Details
- Server uses a 10-second timeout for LiqPay API requests
- Payment is only confirmed if status is "success" or "sandbox"
- Maintains idempotency: if booking is already marked as paid, the operation succeeds silently
- Frontend provides better UX feedback when server confirmation fails, allowing users to retry

https://claude.ai/code/session_01UhL9rSKZ1oMdzjDZXz4hxH