### PR TITLE
Remove magic-link payment tokens; send emails only on actual payment

### DIFF
--- a/tour-server/bookings/api/post_bookings.go
+++ b/tour-server/bookings/api/post_bookings.go
@@ -1,14 +1,9 @@
 package api
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strings"
-	"time"
 	"tour-server/bookings/dto"
 	"tour-server/bookings/models"
 	"tour-server/email"
@@ -127,37 +122,27 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 				"error": "Failed to create booking"})
 		}
 
-		// ── Magic-link payment token for guests ───────────────────────────
-		var paymentURL string
+		// ── Email notification ────────────────────────────────────────────
+		// Guests pay in the LiqPay widget right after booking. If a guest
+		// leaves the widget without paying, that is their decision — we do
+		// not chase them with a payment link. A guest receives an email only
+		// when payment actually goes through ("payment received").
+		// Registered users still get a booking-created notice, since they
+		// have a cabinet where the booking can be paid later.
 		if isGuestBooking {
-			token, err := generatePaymentToken()
-			if err != nil {
-				log.Printf("Failed to generate payment token: %v", err)
-			} else {
-				expiresAt := time.Now().Add(7 * 24 * time.Hour)
-				if err := db.Exec(
-					"UPDATE bookings SET payment_token = ?, payment_token_expires_at = ? WHERE id = ?",
-					token, expiresAt, booking.ID,
-				).Error; err != nil {
-					log.Printf("Failed to save payment token: %v", err)
-				} else {
-					paymentURL = buildPaymentURL(token)
-				}
-			}
+			log.Printf("Guest booking #%d created — awaiting payment, no email sent", booking.ID)
+		} else {
+			tourTitle := getTourTitleByDateID(db, req.TourDateID)
+			email.NotifyBookingCreated(req.CustomerEmail, email.BookingNotification{
+				CustomerName: req.CustomerName,
+				TourTitle:    tourTitle,
+				Seats:        int(req.Seats),
+				TotalPrice:   calculatedPrice,
+				BookingID:    booking.ID,
+				Status:       "pending",
+			})
+			log.Printf("Booking created email queued: #%d → %s", booking.ID, req.CustomerEmail)
 		}
-
-		// ── Email notification (async) ────────────────────────────────────
-		tourTitle := getTourTitleByDateID(db, req.TourDateID)
-		email.NotifyBookingCreated(req.CustomerEmail, email.BookingNotification{
-			CustomerName: req.CustomerName,
-			TourTitle:    tourTitle,
-			Seats:        int(req.Seats),
-			TotalPrice:   calculatedPrice,
-			BookingID:    booking.ID,
-			Status:       "pending",
-			PaymentURL:   paymentURL,
-		})
-		log.Printf("Booking created email queued: #%d → %s", booking.ID, req.CustomerEmail)
 
 		return c.JSON(http.StatusOK, map[string]interface{}{
 			"message":     "Booking successful",
@@ -166,22 +151,6 @@ func PostBookings(db *gorm.DB) echo.HandlerFunc {
 			"total_price": calculatedPrice,
 		})
 	}
-}
-
-func generatePaymentToken() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
-}
-
-func buildPaymentURL(token string) string {
-	base := os.Getenv("FRONTEND_URL")
-	if base == "" {
-		base = "https://openworld.local"
-	}
-	return fmt.Sprintf("%s/pay/%s", base, token)
 }
 
 func getTourTitleByDateID(db *gorm.DB, tourDateID uint) string {

--- a/tour-server/liqpay/api/confirm_payment.go
+++ b/tour-server/liqpay/api/confirm_payment.go
@@ -78,8 +78,15 @@ func ConfirmPayment(db *gorm.DB) echo.HandlerFunc {
 			})
 		}
 
-		if err := confirmBookingByOrder(db, req.OrderID, paymentID); err != nil {
+		transitioned, err := confirmBookingByOrder(db, req.OrderID, paymentID)
+		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		// Send the confirmation email from whichever path (this call or the
+		// LiqPay server callback) first flips the booking to paid — the guest
+		// gets exactly one email even if the callback never reaches us.
+		if transitioned {
+			sendPaymentEmail(db, req.OrderID)
 		}
 
 		return c.JSON(http.StatusOK, map[string]interface{}{
@@ -89,10 +96,13 @@ func ConfirmPayment(db *gorm.DB) echo.HandlerFunc {
 	}
 }
 
-func confirmBookingByOrder(db *gorm.DB, orderID, paymentID string) error {
+// confirmBookingByOrder flips the booking to confirmed/paid. The bool result
+// reports whether this call performed the transition (false if the booking was
+// already paid) so the caller can send the confirmation email exactly once.
+func confirmBookingByOrder(db *gorm.DB, orderID, paymentID string) (bool, error) {
 	tx := db.Begin()
 	if tx.Error != nil {
-		return tx.Error
+		return false, tx.Error
 	}
 
 	var booking struct {
@@ -104,12 +114,12 @@ func confirmBookingByOrder(db *gorm.DB, orderID, paymentID string) error {
 		orderID,
 	).Scan(&booking).Error; err != nil || booking.ID == 0 {
 		tx.Rollback()
-		return fmt.Errorf("booking not found for order %s", orderID)
+		return false, fmt.Errorf("booking not found for order %s", orderID)
 	}
 
 	if booking.PaymentStatus == "paid" {
 		tx.Rollback()
-		return nil
+		return false, nil
 	}
 
 	now := time.Now()
@@ -122,8 +132,11 @@ func confirmBookingByOrder(db *gorm.DB, orderID, paymentID string) error {
 		WHERE liqpay_order_id = ?
 	`, paymentID, now, orderID).Error; err != nil {
 		tx.Rollback()
-		return err
+		return false, err
 	}
 
-	return tx.Commit().Error
+	if err := tx.Commit().Error; err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/tour-server/liqpay/api/liqpay_callback.go
+++ b/tour-server/liqpay/api/liqpay_callback.go
@@ -53,11 +53,11 @@ func LiqPayCallback(db *gorm.DB) echo.HandlerFunc {
 
 		switch status {
 		case "success", "sandbox":
-			if err := confirmBooking(db, orderID, paymentID); err != nil {
+			transitioned, err := confirmBooking(db, orderID, paymentID)
+			if err != nil {
 				log.Printf("LiqPay callback: confirmBooking error: %v", err)
-			} else {
+			} else if transitioned {
 				log.Printf("Booking auto-confirmed: order=%s", orderID)
-				// Send payment confirmation email
 				sendPaymentEmail(db, orderID)
 			}
 
@@ -88,10 +88,12 @@ func LiqPayCallback(db *gorm.DB) echo.HandlerFunc {
 // confirmBooking sets status=confirmed, payment_status=paid.
 // Seats are already reserved (decremented by trigger on INSERT),
 // so no seat adjustment needed for pending→confirmed.
-func confirmBooking(db *gorm.DB, orderID, paymentID string) error {
+// The bool result reports whether this call performed the transition
+// (false if the booking was already paid) so the email is sent once.
+func confirmBooking(db *gorm.DB, orderID, paymentID string) (bool, error) {
 	tx := db.Begin()
 	if tx.Error != nil {
-		return tx.Error
+		return false, tx.Error
 	}
 
 	var booking struct {
@@ -104,14 +106,14 @@ func confirmBooking(db *gorm.DB, orderID, paymentID string) error {
 		orderID,
 	).Scan(&booking).Error; err != nil || booking.ID == 0 {
 		tx.Rollback()
-		return fmt.Errorf("booking not found for order %s", orderID)
+		return false, fmt.Errorf("booking not found for order %s", orderID)
 	}
 
 	// Idempotency — already confirmed, skip
 	if booking.PaymentStatus == "paid" {
 		tx.Rollback()
 		log.Printf("Booking already paid: order=%s", orderID)
-		return nil
+		return false, nil
 	}
 
 	now := time.Now()
@@ -124,10 +126,13 @@ func confirmBooking(db *gorm.DB, orderID, paymentID string) error {
 		WHERE liqpay_order_id = ?
 	`, paymentID, now, orderID).Error; err != nil {
 		tx.Rollback()
-		return err
+		return false, err
 	}
 
-	return tx.Commit().Error
+	if err := tx.Commit().Error; err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // cancelBookingByOrder handles payment reversal:


### PR DESCRIPTION
## Summary
This PR removes the magic-link payment token system for guest bookings and refactors the email notification flow. Guests now pay directly through the LiqPay widget without receiving a payment link via email. Email confirmations are sent only when payment actually succeeds, preventing unnecessary follow-up emails for abandoned transactions.

## Key Changes

- **Removed magic-link payment system**: Deleted `generatePaymentToken()` and `buildPaymentURL()` functions that created time-limited payment links for guests
- **Simplified guest booking flow**: Guest bookings no longer generate or store payment tokens; they proceed directly to the LiqPay widget
- **Conditional email notifications**: 
  - Guest bookings: No email sent on creation (awaiting payment)
  - Registered users: Still receive booking-created notification (can pay later from their cabinet)
- **Idempotent payment confirmation**: Modified `confirmBooking()` and `confirmBookingByOrder()` to return a boolean indicating whether the transition to "paid" status actually occurred
- **Single confirmation email**: Email is sent only by whichever code path (LiqPay callback or confirm endpoint) first transitions the booking to paid status, ensuring guests receive exactly one confirmation email

## Implementation Details

- Removed unused imports: `crypto/rand`, `encoding/hex`, `fmt`, `os`, `time`
- Both `confirmBooking()` (callback handler) and `confirmBookingByOrder()` (confirm endpoint) now return `(bool, error)` to coordinate email sending
- Email sending is guarded by the transition boolean to prevent duplicate notifications
- Booking creation logs now indicate whether email was sent and the reason

https://claude.ai/code/session_01CXz4g7kiAbx7dMv8bguzMJ