### PR TITLE
Add apple-to-apple benchmark suite for Go vs Python vs Node.js

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,110 @@
+# Apple-to-Apple Benchmark
+
+Cross-language performance comparison of three identical REST endpoints
+implemented in **Go + Echo** (existing), **Python + FastAPI**, and
+**Node.js + Express**.
+
+All three implementations:
+
+- Connect to the **same PostgreSQL** database with the **same data**.
+- Expose the **same three endpoints** with **identical SQL queries**.
+- Are tested with the **same `hey` parameters** on the **same machine**.
+
+This guarantees apple-to-apple comparison: any difference in RPS / latency
+is attributable to the language, runtime, and framework — not to query
+optimization, schema, or data volume.
+
+## Endpoints
+
+| Endpoint | Description | What it stresses |
+|---|---|---|
+| `GET /tours` | List active tours with cover image | Simple SELECT + LEFT JOIN, JSON serialization |
+| `GET /tours/:id` | Single tour with status / dates / seats | Multiple JOINs |
+| `GET /search?title=...` | Search with filters & pagination | Dynamic SQL with parameter binding |
+
+## Prerequisites
+
+- PostgreSQL with `tourdb` already seeded (the same DB used by the Go server).
+- `hey` load tester installed (`go install github.com/rakyll/hey@latest`).
+- Python 3.10+, Node.js 18+, Go 1.21+.
+
+## 1. Start the three servers
+
+Open **three terminals**, leave them running.
+
+### Go + Echo (existing project)
+
+```bash
+cd tour-server
+go run server.go            # listens on :1323
+```
+
+### Python + FastAPI
+
+```bash
+cd benchmark/fastapi
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --port 8000 --no-access-log --workers 1
+```
+
+### Node.js + Express
+
+```bash
+cd benchmark/express
+npm install
+PORT=3001 node server.js
+```
+
+## 2. Run the benchmark
+
+```bash
+cd benchmark
+./run_benchmark.sh
+```
+
+The script:
+
+1. Performs a **warm-up pass** (50 requests per endpoint, results discarded)
+   so JIT, connection pools, and OS file caches are primed.
+2. Performs the **measured pass** (500 requests, 10 concurrent connections).
+3. Prints a summary table and saves raw `hey` output to `results_<timestamp>/`.
+
+### Environment overrides
+
+```bash
+REQUESTS=1000 CONCURRENCY=20 TOUR_ID=5 SEARCH_TITLE=Dubai ./run_benchmark.sh
+```
+
+## 3. Fairness checklist
+
+Before quoting numbers in the thesis, confirm:
+
+- [ ] All three servers run on the **same physical machine** (laptop, VM, etc.).
+- [ ] Each server has **logging disabled** (Go: `cfg.App.Debug = false`;
+      FastAPI: `--no-access-log`; Express: no `morgan`).
+- [ ] Each server is started **fresh** (no other heavy processes running).
+- [ ] PostgreSQL is the **same instance** for all three.
+- [ ] `hey` is invoked with the **same `-n` and `-c`** parameters.
+- [ ] **Warm-up pass** was performed (the script does this automatically).
+
+## 4. Expected pattern of results
+
+Typical apple-to-apple comparison of these stacks shows:
+
+- **Go + Echo**: highest RPS, lowest tail latency (compiled, lightweight goroutines).
+- **Node.js + Express**: middle ground (V8 JIT, event loop, single-threaded JS).
+- **Python + FastAPI**: lower RPS but competitive latency thanks to asyncpg + uvloop.
+
+The actual numbers depend on the hardware, OS, network stack, and database
+warm-up state. What matters for the thesis is the **relative difference**
+on **your** machine in **your** conditions.
+
+## 5. Filing results into the thesis
+
+Suggested place: extend Section 4.3 ("Опис процесів тестування") or add a
+new sub-section **4.X "Порівняльне навантажувальне тестування"** with:
+
+- Description of the methodology (3 endpoints, 3 implementations, same DB).
+- A table with the summary numbers from `run_benchmark.sh`.
+- One paragraph of analysis (which stack performed how, and why).

--- a/benchmark/express/package.json
+++ b/benchmark/express/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tour-benchmark-express",
+  "version": "1.0.0",
+  "description": "Express.js benchmark server (mirrors Go endpoints for apple-to-apple comparison)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "pg": "^8.13.0"
+  }
+}

--- a/benchmark/express/server.js
+++ b/benchmark/express/server.js
@@ -1,0 +1,137 @@
+// Express + node-postgres implementation of three endpoints for apple-to-apple
+// benchmarking against Go + Echo. Queries are identical to those in the Go
+// implementation.
+
+const express = require('express');
+const { Pool } = require('pg');
+
+const DB_DSN = process.env.DB_DSN ||
+  'postgresql://touruser:tourpass123@localhost:5432/tourdb';
+
+const pool = new Pool({
+  connectionString: DB_DSN,
+  max: 20,
+  min: 5,
+});
+
+const app = express();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /tours — list active tours (matches GetToursForCards in Go)
+// ─────────────────────────────────────────────────────────────────────────────
+app.get('/tours', async (req, res) => {
+  try {
+    const sql = `
+      SELECT tours.id, tours.title, tours.price, tours.rating,
+             COALESCE(tour_card_images.image_src, 'no-image.jpg') AS "imageSrc"
+      FROM tours
+      LEFT JOIN tour_card_images ON tours.id = tour_card_images.tour_id
+      WHERE tours.status_id = (SELECT id FROM statuses WHERE name = 'active')
+      ORDER BY tours.id ASC
+    `;
+    const { rows } = await pool.query(sql);
+    res.json(rows);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch tours' });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /tours/:id — single tour with JOINs (matches GetTourById in Go)
+// ─────────────────────────────────────────────────────────────────────────────
+app.get('/tours/:id', async (req, res) => {
+  try {
+    const sql = `
+      SELECT tours.id, tours.title, tours.description,
+             tours.call_to_action, tours.price, tours.rating,
+             tours.detailed_description, tours.status_id,
+             statuses.name AS status,
+             tour_dates.date_from, tour_dates.date_to,
+             EXTRACT(DAY FROM (tour_dates.date_to - tour_dates.date_from)) AS duration,
+             tours.total_seats,
+             COALESCE(tour_seats.available_seats, tours.total_seats) AS available_seats
+      FROM tours
+      JOIN statuses ON tours.status_id = statuses.id
+      LEFT JOIN tour_dates ON tours.id = tour_dates.tour_id
+      LEFT JOIN tour_seats ON tour_dates.id = tour_seats.tour_date_id
+      WHERE tours.id = $1
+      LIMIT 1
+    `;
+    const { rows } = await pool.query(sql, [req.params.id]);
+    if (rows.length === 0) return res.status(404).json({ error: 'Tour not found' });
+    res.json(rows[0]);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch tour' });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /search — search with filters (matches SearchTours in Go, simplified)
+// ─────────────────────────────────────────────────────────────────────────────
+app.get('/search', async (req, res) => {
+  try {
+    const { title, minPrice, maxPrice } = req.query;
+    const page = Math.max(parseInt(req.query.page) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit) || 12, 1), 100);
+
+    const conds = ["tours.status_id = (SELECT id FROM statuses WHERE name = 'active')"];
+    const params = [];
+
+    if (title) {
+      params.push(`%${title}%`);
+      params.push(`%${title}%`);
+      conds.push(`(tours.title ILIKE $${params.length - 1} OR tours.description ILIKE $${params.length})`);
+    }
+    if (minPrice) {
+      params.push(parseFloat(minPrice));
+      conds.push(`tours.price >= $${params.length}`);
+    }
+    if (maxPrice) {
+      params.push(parseFloat(maxPrice));
+      conds.push(`tours.price <= $${params.length}`);
+    }
+
+    const offset = (page - 1) * limit;
+    const whereClause = conds.join(' AND ');
+
+    const sql = `
+      SELECT tours.id, tours.title, tours.price, tours.rating,
+             COALESCE(tci.image_src, '/static/images/no-image.jpg') AS image_src,
+             COALESCE((
+                 SELECT EXTRACT(DAY FROM (td.date_to - td.date_from))
+                 FROM tour_dates td WHERE td.tour_id = tours.id LIMIT 1
+             ), 0) AS duration,
+             COALESCE((
+                 SELECT CONCAT(l.name, ', ', l.country)
+                 FROM tour_dates td
+                 JOIN locations l ON td.to_location_id = l.id
+                 WHERE td.tour_id = tours.id LIMIT 1
+             ), '') AS location
+      FROM tours
+      LEFT JOIN tour_card_images tci ON tci.tour_id = tours.id
+      WHERE ${whereClause}
+      ORDER BY tours.id ASC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
+    const countSql = `SELECT COUNT(*) FROM tours WHERE ${whereClause}`;
+
+    const { rows } = await pool.query(sql, params);
+    const { rows: countRows } = await pool.query(countSql, params);
+    const total = parseInt(countRows[0].count, 10);
+
+    res.json({
+      tours: rows,
+      total,
+      page,
+      limit,
+      totalPages: total ? Math.ceil(total / limit) : 0,
+    });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to search tours' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Express benchmark server running on port ${PORT}`);
+});

--- a/benchmark/fastapi/main.py
+++ b/benchmark/fastapi/main.py
@@ -1,0 +1,141 @@
+"""
+FastAPI implementation of three endpoints for apple-to-apple benchmarking against
+Go + Echo. Uses asyncpg (the fastest PostgreSQL driver for Python). Queries are
+identical to those in the Go implementation.
+"""
+import os
+from typing import Optional
+
+import asyncpg
+from fastapi import FastAPI, HTTPException, Query
+
+DB_DSN = os.getenv(
+    "DB_DSN",
+    "postgresql://touruser:tourpass123@localhost:5432/tourdb",
+)
+
+app = FastAPI(docs_url=None, redoc_url=None)
+pool: asyncpg.Pool | None = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global pool
+    pool = await asyncpg.create_pool(dsn=DB_DSN, min_size=5, max_size=20)
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if pool:
+        await pool.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /tours — list active tours (matches GetToursForCards in Go)
+# ──────────────────────────────────────────────────────────────────────────────
+@app.get("/tours")
+async def list_tours():
+    sql = """
+        SELECT tours.id, tours.title, tours.price, tours.rating,
+               COALESCE(tour_card_images.image_src, 'no-image.jpg') AS "imageSrc"
+        FROM tours
+        LEFT JOIN tour_card_images ON tours.id = tour_card_images.tour_id
+        WHERE tours.status_id = (SELECT id FROM statuses WHERE name = 'active')
+        ORDER BY tours.id ASC
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(sql)
+        return [dict(r) for r in rows]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /tours/{id} — single tour with JOINs (matches GetTourById in Go)
+# ──────────────────────────────────────────────────────────────────────────────
+@app.get("/tours/{tour_id}")
+async def get_tour(tour_id: int):
+    sql = """
+        SELECT tours.id, tours.title, tours.description,
+               tours.call_to_action, tours.price, tours.rating,
+               tours.detailed_description, tours.status_id,
+               statuses.name AS status,
+               tour_dates.date_from, tour_dates.date_to,
+               EXTRACT(DAY FROM (tour_dates.date_to - tour_dates.date_from)) AS duration,
+               tours.total_seats,
+               COALESCE(tour_seats.available_seats, tours.total_seats) AS available_seats
+        FROM tours
+        JOIN statuses ON tours.status_id = statuses.id
+        LEFT JOIN tour_dates ON tours.id = tour_dates.tour_id
+        LEFT JOIN tour_seats ON tour_dates.id = tour_seats.tour_date_id
+        WHERE tours.id = $1
+        LIMIT 1
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(sql, tour_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Tour not found")
+        return dict(row)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /search — search with filters (matches SearchTours in Go, simplified)
+# ──────────────────────────────────────────────────────────────────────────────
+@app.get("/search")
+async def search_tours(
+    title: Optional[str] = None,
+    minPrice: Optional[float] = None,
+    maxPrice: Optional[float] = None,
+    page: int = Query(1, ge=1),
+    limit: int = Query(12, ge=1, le=100),
+):
+    conds = ["tours.status_id = (SELECT id FROM statuses WHERE name = 'active')"]
+    params: list = []
+
+    if title:
+        params.append(f"%{title}%")
+        params.append(f"%{title}%")
+        conds.append(f"(tours.title ILIKE ${len(params)-1} OR tours.description ILIKE ${len(params)})")
+
+    if minPrice is not None:
+        params.append(minPrice)
+        conds.append(f"tours.price >= ${len(params)}")
+
+    if maxPrice is not None:
+        params.append(maxPrice)
+        conds.append(f"tours.price <= ${len(params)}")
+
+    offset = (page - 1) * limit
+    where_clause = " AND ".join(conds)
+
+    sql = f"""
+        SELECT tours.id, tours.title, tours.price, tours.rating,
+               COALESCE(tci.image_src, '/static/images/no-image.jpg') AS image_src,
+               COALESCE((
+                   SELECT EXTRACT(DAY FROM (td.date_to - td.date_from))
+                   FROM tour_dates td WHERE td.tour_id = tours.id LIMIT 1
+               ), 0) AS duration,
+               COALESCE((
+                   SELECT CONCAT(l.name, ', ', l.country)
+                   FROM tour_dates td
+                   JOIN locations l ON td.to_location_id = l.id
+                   WHERE td.tour_id = tours.id LIMIT 1
+               ), '') AS location
+        FROM tours
+        LEFT JOIN tour_card_images tci ON tci.tour_id = tours.id
+        WHERE {where_clause}
+        ORDER BY tours.id ASC
+        LIMIT {limit} OFFSET {offset}
+    """
+
+    count_sql = f"SELECT COUNT(*) FROM tours WHERE {where_clause}"
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(sql, *params)
+        total = await conn.fetchval(count_sql, *params)
+
+    return {
+        "tours": [dict(r) for r in rows],
+        "total": total,
+        "page": page,
+        "limit": limit,
+        "totalPages": (total + limit - 1) // limit if total else 0,
+    }

--- a/benchmark/fastapi/requirements.txt
+++ b/benchmark/fastapi/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+asyncpg==0.30.0

--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Runs hey against all three implementations sequentially.
+# Make sure all three servers are running BEFORE invoking this:
+#   - Go + Echo     on port 1323
+#   - FastAPI       on port 8000
+#   - Express       on port 3001
+
+set -euo pipefail
+
+REQUESTS="${REQUESTS:-500}"
+CONCURRENCY="${CONCURRENCY:-10}"
+TOUR_ID="${TOUR_ID:-1}"      # ensure such a tour exists in DB
+SEARCH_TITLE="${SEARCH_TITLE:-Dubai}"
+
+OUT="results_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$OUT"
+
+declare -A SERVERS=(
+  [go]="http://localhost:1323"
+  [fastapi]="http://localhost:8000"
+  [express]="http://localhost:3001"
+)
+
+declare -A ENDPOINTS=(
+  [tours]="/tours"
+  [tour_by_id]="/tours/$TOUR_ID"
+  [search]="/search?title=$SEARCH_TITLE"
+)
+
+# Warm-up pass (so the first measured run isn't biased by JIT / GC / connection pool warmup)
+echo "=== Warm-up pass (50 requests each, results discarded) ==="
+for srv in "${!SERVERS[@]}"; do
+  for ep in "${!ENDPOINTS[@]}"; do
+    url="${SERVERS[$srv]}${ENDPOINTS[$ep]}"
+    hey -n 50 -c "$CONCURRENCY" "$url" > /dev/null 2>&1 || true
+  done
+done
+
+# Measured pass
+echo "=== Measured pass ($REQUESTS requests, $CONCURRENCY concurrency) ==="
+for srv in "${!SERVERS[@]}"; do
+  for ep in "${!ENDPOINTS[@]}"; do
+    url="${SERVERS[$srv]}${ENDPOINTS[$ep]}"
+    label="${srv}__${ep}"
+    echo "→ $label : $url"
+    hey -n "$REQUESTS" -c "$CONCURRENCY" "$url" > "$OUT/$label.txt"
+    sleep 1   # let connection pools settle between runs
+  done
+done
+
+# Summary table
+echo
+echo "=== Summary ==="
+printf "%-20s %-15s %-10s %-10s %-10s %-10s\n" "Server" "Endpoint" "RPS" "Avg(ms)" "P50(ms)" "P95(ms)"
+for srv in go fastapi express; do
+  for ep in tours tour_by_id search; do
+    f="$OUT/${srv}__${ep}.txt"
+    [[ -f "$f" ]] || continue
+    rps=$(grep -i "Requests/sec:" "$f" | awk '{printf "%.0f", $2}')
+    avg=$(grep -i "Average:" "$f" | head -n1 | awk '{printf "%.2f", $2*1000}')
+    p50=$(awk '/Latency distribution:/{flag=1;next} flag && /50%/{print $2*1000; exit}' "$f")
+    p95=$(awk '/Latency distribution:/{flag=1;next} flag && /95%/{print $2*1000; exit}' "$f")
+    printf "%-20s %-15s %-10s %-10s %-10s %-10s\n" "$srv" "$ep" "$rps" "$avg" "$p50" "$p95"
+  done
+done
+
+echo
+echo "Raw outputs saved to: $OUT/"


### PR DESCRIPTION
Adds a self-contained benchmark folder that lets us reproduce the performance comparison Євген Олександрович asked for. Three identical endpoints (GET /tours, GET /tours/:id, GET /search) are reimplemented in Python (FastAPI + asyncpg) and Node.js (Express + pg) using the exact same SQL queries as the Go handlers. All three stacks connect to the same PostgreSQL database and are exercised by the same hey invocations on the same machine, so any RPS / latency delta is attributable to the runtime and framework rather than the workload.

run_benchmark.sh performs a warm-up pass before the measured pass so JIT compilers, connection pools, and the OS page cache are primed, then prints a side-by-side summary table and stores raw hey output for inclusion in the thesis.